### PR TITLE
Port the longest ORF function to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rnasamba"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Antonio Camargo <antoniop.camargo@gmail.com>"]
 edition = "2018"
 
@@ -13,6 +13,7 @@ itertools = "0.8.1"
 ndarray = "0.13.0"
 numpy = "0.7.0"
 rayon = "1.2.0"
+regex = "1.3.1"
 
 [dependencies.pyo3]
 version = "0.8.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install --no-cache-dir \
     'biopython==1.74' \
     'keras==2.2.5' \
     'numpy==1.16.5' \
-    'rnasamba==0.2.1' \
+    'rnasamba==0.2.2' \
     'tensorflow==1.14.0'
 
 VOLUME ["/app"]

--- a/rnasamba/cli.py
+++ b/rnasamba/cli.py
@@ -48,7 +48,7 @@ def train(args):
 
 
 def classify_cli(parser):
-    parser.add_argument('--version', action='version', version='%(prog)s 0.2.1')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.2.2')
     parser.set_defaults(func=classify)
     parser.add_argument(
         'output_file',
@@ -79,7 +79,7 @@ def classify_cli(parser):
 
 def train_cli(parser):
     parser.set_defaults(func=train)
-    parser.add_argument('--version', action='version', version='%(prog)s 0.2.1')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.2.2')
     parser.add_argument(
         'output_file',
         help='output HDF5 file containing weights of the newly trained RNAsamba network.',
@@ -128,7 +128,7 @@ def cli():
         description='Coding potential calculation using deep learning.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument('--version', action='version', version='%(prog)s 0.2.1')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.2.2')
     subparsers = parser.add_subparsers()
     classify_parser = subparsers.add_parser(
         'classify',

--- a/rnasamba/core/inputs.py
+++ b/rnasamba/core/inputs.py
@@ -19,8 +19,7 @@
 #   Contact: antoniop.camargo@gmail.com
 
 from keras.preprocessing.sequence import pad_sequences
-
-from rnasamba.core import sequences, kmer
+from rnasamba.core import kmer, orf, sequences
 
 
 class RNAsambaInput:
@@ -62,7 +61,7 @@ class RNAsambaInput:
         self.sequence_name = [seq[1] for seq in self._nucleotide_sequences]
 
     def get_orfs(self):
-        orfs = [sequences.longest_orf(seq[0]) for seq in self._nucleotide_sequences]
+        orfs = orf.longest_orf_array(self._nucleotide_sequences)
         return orfs
 
     def get_nucleotide_input(self):

--- a/rnasamba/core/sequences.py
+++ b/rnasamba/core/sequences.py
@@ -18,12 +18,10 @@
 #
 #   Contact: antoniop.camargo@gmail.com
 
-import itertools
-import re
 from collections import Counter
 
 import numpy as np
-from Bio import Seq, SeqIO
+from Bio import SeqIO
 from keras.preprocessing.sequence import pad_sequences
 from keras.utils import to_categorical
 
@@ -51,19 +49,6 @@ def tokenize_dna(sequence):
     else:
         token = [lookup[c] for c in sequence if c in lookup]
     return token
-
-
-def longest_orf(sequence):
-    start_codon = re.compile('ATG')
-    longest = (0, 0, '')
-    for m in start_codon.finditer(sequence):
-        putative_orf = sequence[m.start() :]
-        # Add trailing Ns to make the sequence length a multiple of three:
-        putative_orf = putative_orf + 'N' * (3 - len(putative_orf) % 3)
-        protein = Seq.Seq(putative_orf).translate(to_stop=True)
-        if len(protein) > longest[0]:
-            longest = (len(protein), m.start(), str(protein))
-    return longest
 
 
 def orf_indicator(orfs, maxlen):

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,12 @@ from setuptools_rust import RustExtension
 
 setup(
     name='rnasamba',
-    version='0.2.1',
+    version='0.2.2',
     packages=find_packages(),
-    rust_extensions=[RustExtension('rnasamba.core.kmer', debug=False)],
+    rust_extensions=[
+        RustExtension('rnasamba.core.kmer', debug=False),
+        RustExtension('rnasamba.core.orf', debug=False),
+    ],
     zip_safe=False,
     license='GNU General Public License v3.0',
     description='A tool for computing the coding potential of RNA transcript sequences using deep learning.',


### PR DESCRIPTION
- The `longest_orf` function is now written in Rust and is ~50 times faster.
- The ORF extraction step is now parallelized.